### PR TITLE
Bump ZK verstion to 3.8.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ COPY zu /zu
 WORKDIR /zu
 RUN ./gradlew --console=verbose --info shadowJar
 
-FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}zookeeper:3.7.1
+FROM ${DOCKER_REGISTRY:+$DOCKER_REGISTRY/}zookeeper:3.8.2
 COPY bin /usr/local/bin
 RUN chmod +x /usr/local/bin/*
 COPY --from=0 /zu/build/libs/zu.jar /opt/libs/


### PR DESCRIPTION
Bump zookeeper from 3.7.1 to 3.8.2 (last stable version)

### Change log description

upgrade zookeeper version to 3.8.2

### Purpose of the change

Maybe not relate to 3.7.1 but I get error, Failed to load class "org.slf4j.impl.StaticLoggerBinder", in version 3.8.2 runs fine.

### What the code does

Just upgrade default version in Dockerfile.

### How to verify it

 make build-zk-image, runs fine. 
